### PR TITLE
first feature of the store service

### DIFF
--- a/services/store/build.gradle
+++ b/services/store/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'java'
+sourceCompatibility = 1.8
+repositories {
+    mavenCentral()
+}
+dependencies {
+    compile "io.vertx:vertx-core:2.1.2"
+    compile "io.vertx:vertx-platform:2.1.2"
+    testCompile "io.vertx:testtools:2.0.3-final"
+}

--- a/services/store/settings.gradle
+++ b/services/store/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'store'

--- a/services/store/src/main/java/fr/xebia/vertx/store/StoreVerticle.java
+++ b/services/store/src/main/java/fr/xebia/vertx/store/StoreVerticle.java
@@ -1,0 +1,47 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fr.xebia.vertx.store;
+
+import java.util.UUID;
+import org.vertx.java.core.Future;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.java.platform.Verticle;
+
+/**
+ *
+ * @author Xebia
+ */
+public class StoreVerticle extends Verticle {
+
+    private long orderRate;
+    private int quantity;
+    private String id;
+    private long periodicId;
+
+    @Override
+    public void start(Future<Void> startedResult) {
+
+        orderRate = container.config().getLong("orderRate", 1000);
+        quantity = container.config().getInteger("quantity", 10);
+        id = "store-" + UUID.randomUUID().toString();
+
+        /*
+         * Send periodicaly an order to every factory
+         */
+        periodicId = vertx.setPeriodic(orderRate, l -> {
+            JsonObject order = new JsonObject();
+            order.putString("action", "order");
+            order.putString("from", id);
+            order.putNumber("quantity", quantity);
+            vertx.eventBus().publish("city.factory", order);
+        });
+        /*
+         * the starting of the module is successful
+         */
+        startedResult.setResult(null);
+    }
+
+}

--- a/services/store/src/test/java/fr/xebia/vertx/store/integration/java/TestStore.java
+++ b/services/store/src/test/java/fr/xebia/vertx/store/integration/java/TestStore.java
@@ -1,0 +1,77 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fr.xebia.vertx.store.integration.java;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.vertx.java.core.json.JsonObject;
+import org.vertx.testtools.TestVerticle;
+import org.vertx.testtools.VertxAssert;
+import static org.vertx.testtools.VertxAssert.fail;
+import static org.vertx.testtools.VertxAssert.testComplete;
+
+/**
+ *
+ * @author xebia
+ */
+public class TestStore extends TestVerticle {
+
+    /*
+     * Build the conf of the store.
+     */
+    private JsonObject buildConf() {
+        JsonObject conf = new JsonObject();
+        conf.putNumber("orderRate", 1000);
+        conf.putNumber("quantity", 10);
+        return new JsonObject();
+    }
+
+    /**
+     * TEst that a store will send one orders to one listening factory
+     */
+    @Test
+    public void testSendOrder() {
+        /*
+         *Expected object.
+         */
+        JsonObject expected = new JsonObject();
+        expected.putString("action", "order");
+        expected.putString("from", "randomID");
+        expected.putNumber("quantity", 10);
+
+        /*
+         * Set a time out for the test => 10 secs
+         */
+        long timeOutTask = vertx.setPeriodic(10000, l -> {
+            container.logger().error("Time out reache for test : testSendOrder");
+            fail();
+        });
+        vertx.eventBus().registerHandler("city.factory", m -> {
+            container.logger().info("receive a message from somebody");
+            /*
+             * reset the timer
+             */
+            vertx.cancelTimer(timeOutTask);
+            /*
+             * check the JsonObject received
+             */
+            if (m.body() != null && m.body() instanceof JsonObject) {
+                JsonObject received = (JsonObject) m.body();
+                VertxAssert.assertEquals(received.getString("action"), expected.getString("action"));
+                VertxAssert.assertTrue(received.getString("from").startsWith("store"));
+                VertxAssert.assertEquals(received.getNumber("quantity"), expected.getNumber("quantity"));
+            } else {
+                fail();
+            }
+            testComplete();
+
+        });
+        container.deployVerticle("fr.xebia.vertx.store.StoreVerticle", buildConf(), 1, (res) -> {
+
+        });
+    }
+
+}


### PR DESCRIPTION
Première version du store service. Envoi des régulièrement des commandes "simple". Je me suis basé sur le premier point de l'issue 16 pour réaliser cette permière feature.

Nb : pour le moment, il manque le fichier de conf, mais il n' y en a pas besoin pour valider le tout... Les outils de tests d'intégration fournis avec vert.x font le job.
